### PR TITLE
downgrade windows version used in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
 # ==============================================================================
 
   clang-tidy:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       fail-fast: false
@@ -224,7 +224,7 @@ jobs:
         fixesFile: clang-tidy-fixes.yml
 
   clang-format:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Setup Clang


### PR DESCRIPTION
thoughts are this will link against an older vcredist, which is more likely to work under proton