### PR TITLE
change ci back to windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
 # ==============================================================================
 
   clang-tidy:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       fail-fast: false
@@ -224,7 +224,7 @@ jobs:
         fixesFile: clang-tidy-fixes.yml
 
   clang-format:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
     - name: Setup Clang


### PR DESCRIPTION
this was originally changed in a6165de6, since plugin loader requiring a newer vc redist was causing a lot of crashes on launch

recently however, we've had a lot of people running one new enough for plugin loader, but too old for unrealsdk this causes the sdk to completely silently fail to load

reverting this change, failing loudly is better