### PR TITLE
Add Save Options Module

### DIFF
--- a/src/save_options/__init__.py
+++ b/src/save_options/__init__.py
@@ -1,0 +1,70 @@
+
+import save_options.hooks  # noqa: F401  # pyright: ignore[reportUnusedImport]
+from mods_base.mod_list import base_mod
+from save_options.options import (
+    BoolSaveOption,
+    HiddenSaveOption,
+    SaveOption,
+    SliderSaveOption,
+    SpinnerSaveOption,
+)
+from save_options.registration import register_save_options
+
+__all__: tuple[str, ...] = (
+    "BoolSaveOption",
+    "HiddenSaveOption",
+    "SaveOption",
+    "SliderSaveOption",
+    "SpinnerSaveOption",
+    "__author__",
+    "__version__",
+    "__version_info__",
+    "register_save_options",
+)
+
+__version_info__: tuple[int, int] = (1, 0)
+__version__: str = f"{__version_info__[0]}.{__version_info__[1]}"
+__author__: str = "bl-sdk"
+
+"""This library allows for any arbitrary JSON encodable data to be saved in the character's .sav
+file. You will manage the data that will be written to the save file by storing values in special
+SaveOption objects. These objects all inherit from ValueOption objects as defined in mods_base,
+but provide some additional functionality:
+
+- When no player save is available (main menu with no character), the options behave as button
+  options, with a message showing that a player needs to be loaded.
+- Values from the options will be saved to and loaded from the character save files. If the option
+  is also registered in the mod as a regular option (i.e., in Mod.options), the options will also
+  save to the mod's settings
+file. These values will be loaded for any character that has not had any values saved yet. If you
+don't want a save option to be stored in the mod settings file, make sure it is not added to
+Mod.options.
+
+Once the SaveOptions are registered, they are used in two places:
+1. A hook on WillowSaveGameManager:SaveGame, where the values from the save options are read and
+   written to the save file. Optionally, a save callback may be registered that runs before the save
+   file is written. You can use this callback to do any just-in-time updates of the save entries
+   (e.g., get data from the WPC that you would like saved).
+2. A hook on WillowSaveGameManager:EndLoadGame, where the data previously written to the save file
+   is parsed and applied to the registered save options.
+
+Additionally, there is a trigger that saves the game whenever we leave the options menu and ANY
+save option has changed. This keeps the save file up to date if a value is changed on the mod
+options menu. Otherwise the value would be overwritten by the old value when we load into the game.
+
+Example usage for saving anarchy stacks:
+```
+anarchy_save_option = HiddenSaveOption("anarchy", 0)
+def on_save():
+    anarchy_save_option.value = get_anarchy_stacks()
+
+def on_load():
+    set_anarchy_stacks(anarchy_save_option.value)
+
+mod = build_mod()
+register_save_options(mod)
+```
+
+"""
+
+base_mod.components.append(base_mod.ComponentInfo("Save Options", __version__))

--- a/src/save_options/__init__.py
+++ b/src/save_options/__init__.py
@@ -1,4 +1,3 @@
-
 import save_options.hooks  # noqa: F401  # pyright: ignore[reportUnusedImport]
 from mods_base.mod_list import base_mod
 from save_options.options import (
@@ -35,10 +34,9 @@ but provide some additional functionality:
   options, with a message showing that a player needs to be loaded.
 - Values from the options will be saved to and loaded from the character save files. If the option
   is also registered in the mod as a regular option (i.e., in Mod.options), the options will also
-  save to the mod's settings
-file. These values will be loaded for any character that has not had any values saved yet. If you
-don't want a save option to be stored in the mod settings file, make sure it is not added to
-Mod.options.
+  save to the mod's settings file. These values will be loaded for any character that has not had
+  any values saved yet. If you don't want a save option to be stored in the mod settings file, make
+  sure it is not added to Mod.options.
 
 Once the SaveOptions are registered, they are used in two places:
 1. A hook on WillowSaveGameManager:SaveGame, where the values from the save options are read and
@@ -47,6 +45,9 @@ Once the SaveOptions are registered, they are used in two places:
    (e.g., get data from the WPC that you would like saved).
 2. A hook on WillowSaveGameManager:EndLoadGame, where the data previously written to the save file
    is parsed and applied to the registered save options.
+
+An optional on_load can be defined that runs immediately after regular save data is applied to the
+character upon loading into the game.
 
 Additionally, there is a trigger that saves the game whenever we leave the options menu and ANY
 save option has changed. This keeps the save file up to date if a value is changed on the mod

--- a/src/save_options/hooks.py
+++ b/src/save_options/hooks.py
@@ -1,0 +1,165 @@
+import json
+from json import JSONDecodeError
+from typing import Any
+
+from unrealsdk import logging, make_struct
+from unrealsdk.hooks import Type
+from unrealsdk.unreal import BoundFunction, UObject, WrappedStruct
+
+import save_options.options
+from mods_base import JSON, get_pc, hook
+from save_options.options import trigger_save
+from save_options.registration import (
+    ModSaveOptions,
+    load_callbacks,
+    registered_mods,
+    registered_save_options,
+    save_callbacks,
+)
+
+# Value doesn't matter, just needs to be consistent and higher than any real DLC package ID
+_PACKAGE_ID: int = 99
+
+
+def _extract_save_data(
+    lockout_list: list[WrappedStruct],
+) -> tuple[dict[str, dict[str, JSON]], list[WrappedStruct]]:
+    # Grab the json string from UnloadableDlcLockoutList based on the package id, then load to
+    # Python object. Returns empty dict if no data found. Returns the remaining lockout_list
+    # as the second element of a tuple so as not to overwrite unrelated data."""
+
+    matching_lockout_data = next(
+        (lockout_data for lockout_data in lockout_list if lockout_data.DlcPackageId == _PACKAGE_ID),
+        None,
+    )
+    if not matching_lockout_data:
+        return {}, lockout_list
+
+    # Preserve other package Ids on the off chance someone else uses this.
+    lockout_list_other = [
+        lockout_data for lockout_data in lockout_list if lockout_data.DlcPackageId != _PACKAGE_ID
+    ]
+
+    extracted_save_data: dict[str, dict[str, JSON]] = {}
+    if matching_lockout_data.LockoutDefName:
+        try:
+            extracted_save_data = json.loads(matching_lockout_data.LockoutDefName)
+        except JSONDecodeError:
+            # Invalid data, just clear the contents
+            extracted_save_data = {}
+        # Pylance saying this instance check unnecessary, but json.loads can return valid non-dict
+        # objects.
+        if not isinstance(extracted_save_data, dict):  # type: ignore
+            logging.error(
+                f"Could not load dict object from custom save string:"
+                f"{matching_lockout_data.LockoutDefName}"  # noqa: COM812
+            )
+            extracted_save_data = {}
+    return extracted_save_data, lockout_list_other
+
+
+@hook("WillowGame.WillowSaveGameManager:SaveGame", immediately_enable=True)
+def save_game(_1: UObject, args: WrappedStruct, _3: Any, _4: BoundFunction) -> None:  # noqa: D103
+    # We're going to inject our arbitrary save data here. This is the last time the save game can be
+    # edited before writing to disk. Extremely large string sizes can crash the game, so we may want
+    # to add a safety check at some point.1M characters has worked fine, so unlikely to be an issue.
+
+    # For callbacks, only process enabled mods and only when we're in game. We'll run these first so
+    # mod can use it to set values on the save options.
+    enabled_mods = [mod_id for mod_id, mod in registered_mods.items() if mod.is_enabled]
+
+    if get_pc().GetWillowPlayerPawn():
+        callbacks_to_process = {
+            mod_id: callback
+            for mod_id, callback in save_callbacks.items()
+            if mod_id in enabled_mods
+        }
+
+        for callback in callbacks_to_process.values():
+            callback()
+
+    # For saving, we'll overwrite existing mod data for enabled mods. Any disabled/uninstalled mods
+    # will have their data left alone.
+    json_save_data, lockout_list = _extract_save_data(args.SaveGame.UnloadableDlcLockoutList)
+    for mod_id, mod_data in registered_save_options.items():
+        if mod_id in enabled_mods:
+            mod_save_data = {
+                identifier: option_json
+                for identifier, save_option in mod_data.items()
+                if (option_json := save_option._to_json()) is not ...  # type: ignore
+            }
+            try:
+                json.dumps(mod_save_data)
+                json_save_data[mod_id] = mod_save_data
+            except TypeError:
+                logging.error(
+                    f"Could not save data for {mod_id}. Data is not json encodable:{mod_save_data}"  # noqa: COM812
+                )
+
+    str_save_data = json.dumps(json_save_data)
+    custom_lockout = make_struct(
+        "UnloadableDlcLockoutData",
+        LockoutDefName=str_save_data,
+        DlcPackageId=_PACKAGE_ID,
+    )
+    lockout_list.append(custom_lockout)
+    args.SaveGame.UnloadableDlcLockoutList = lockout_list
+
+    # Reset our var tracking whether any options have changed since last save.
+    save_options.options.any_option_changed = False
+
+
+@hook("WillowGame.WillowSaveGameManager:EndLoadGame", Type.POST, immediately_enable=True)
+def end_load_game(_1: UObject, _2: WrappedStruct, ret: Any, _4: BoundFunction) -> None:  # noqa: D103
+    # We hook this to send data back to any registered mod save options. This gets called when
+    # loading character in main menu also. No callback here because the timing of when this is
+    # called doesn't make much sense to do anything with it. See hook on LoadPlayerSaveGame.
+    if ret:
+        extracted_save_data, _ = _extract_save_data(ret.UnloadableDlcLockoutList)
+    else:
+        return
+
+    if not extracted_save_data:
+        return
+
+    for mod_id, extracted_mod_data in extracted_save_data.items():
+        mod_save_options: ModSaveOptions = registered_save_options[mod_id]
+        for identifier, extracted_value in extracted_mod_data.items():
+            if save_option := mod_save_options.get(identifier):
+                save_option._from_json(extracted_value)  # type: ignore
+
+    # Resetting change tracking var here too. Obviously a load sets a bunch of options, but we don't
+    # want to count that as a real change that needs to be saved.
+    save_options.options.any_option_changed = False
+
+
+@hook(
+    "WillowGame.WillowPlayerController:LoadPlayerSaveGame",
+    Type.POST,
+    immediately_enable=True,
+)
+def load_player_save_game(*_: Any) -> None:  # noqa: D103
+    # This function is responsible for applying all save data to the character on loading into a
+    # map. We use it to run callbacks, with the intent that any save data a mod wants to apply to
+    # the player can be done here. At this point, save options have already been populated with
+    # data from the save file through the EndLoadGame hook.
+    enabled_mods = [mod_id for mod_id, mod in registered_mods.items() if mod.is_enabled]
+    callbacks_to_process = {
+        mod_id: callback for mod_id, callback in load_callbacks.items() if mod_id in enabled_mods
+    }
+
+    for callback in callbacks_to_process.values():
+        callback()
+
+
+@hook("WillowGame.FrontendGFxMovie:HideOptionsMovie", immediately_enable=True)
+def hide_options_movie(*_: Any) -> None:  # noqa: D103
+    # When an options movie is closed, we check to see if any save option values have changed since
+    # the last time the file was saved. If it has, we save the game. This is necessary since values
+    # changed while in the main menu would get overwritten or just get lost if a new character were
+    # selected.
+
+    if not save_options.options.any_option_changed:
+        return
+
+    trigger_save()

--- a/src/save_options/options.py
+++ b/src/save_options/options.py
@@ -64,7 +64,9 @@ def trigger_save() -> None:
         # Need to prevent our hook on EndLoadGame to avoid reloading previous save option values
         with prevent_hooking_direct_calls():
             player_save_game = save_manager.EndLoadGame(
-                pc.GetMyControllerId(), make_struct("LoadInfo"), 0,
+                pc.GetMyControllerId(),
+                make_struct("LoadInfo"),
+                0,
             )[0]
         save_manager.SaveGame(
             pc.GetMyControllerId(),
@@ -85,7 +87,12 @@ class SaveOptionMeta(type(ValueOption)):
     """
 
     def __init__(
-        cls, name: str, bases: tuple[type, ...], namespace: dict[str, Any], /, **kwargs: Any,  # noqa: ARG002
+        cls,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        /,
+        **kwargs: Any,  # noqa: ARG002
     ) -> None:
         super().__init__(name, bases, namespace)
 

--- a/src/save_options/options.py
+++ b/src/save_options/options.py
@@ -1,0 +1,257 @@
+from dataclasses import dataclass
+from typing import Any
+
+from unrealsdk import make_struct
+from unrealsdk.hooks import Type, prevent_hooking_direct_calls
+
+from mods_base import (
+    JSON,
+    BoolOption,
+    ButtonOption,
+    HiddenOption,
+    SliderOption,
+    SpinnerOption,
+    ValueOption,
+    get_pc,
+    hook,
+)
+
+any_option_changed: bool = False
+
+
+def can_save() -> bool:
+    """Checks if a character is loaded that we can save to."""
+    pc = get_pc()
+    if not pc:
+        return False
+    cached_save = pc.GetCachedSaveGame()
+    # SaveGameId of -1 is used when a new game is selected but user exits before starting the game
+    return not (not cached_save or cached_save.SaveGameId == -1)
+
+
+def trigger_save() -> None:
+    """
+    Trigger a save game that stores our current save option values.
+
+    When in the main menu, this will just overwrite the save options values and leave the rest of
+    the save untouched. When in game, pc.SaveGame() is called and the save game is generated from
+    the current state as usual.
+    """
+
+    if not can_save():
+        return
+
+    pc = get_pc()
+    # When in game, just use standard machinery to save
+    if pc.MyWillowPawn:
+        pc.SaveGame()
+        return
+
+    # When not in game, we need to load from file to get full save. Cached save game is partial.
+    save_manager = pc.GetWillowGlobals().GetWillowSaveGameManager()
+    setattr(save_manager, "__OnLoadComplete__Delegate", save_manager.OnLoadComplete)
+
+    # Loading the save game is an async operation, we need to hook OnLoadComplete to have access
+    # to the result
+    @hook(
+        "WillowGame.WillowSaveGameManager:OnLoadComplete",
+        Type.POST,
+        immediately_enable=True,
+    )
+    def on_load_complete(*_: Any) -> None:
+        on_load_complete.disable()
+        setattr(save_manager, "__OnLoadComplete__Delegate", None)
+        # Need to prevent our hook on EndLoadGame to avoid reloading previous save option values
+        with prevent_hooking_direct_calls():
+            player_save_game = save_manager.EndLoadGame(
+                pc.GetMyControllerId(), make_struct("LoadInfo"), 0,
+            )[0]
+        save_manager.SaveGame(
+            pc.GetMyControllerId(),
+            player_save_game,
+            save_manager.LastLoadedFilePath,
+            -1,
+        )
+
+    save_manager.BeginLoadGame(pc.GetMyControllerId(), save_manager.LastLoadedFilePath, -1)
+
+
+class SaveOptionMeta(type(ValueOption)):
+    """
+    Metaclass to create save option classes.
+
+    Enforces that usages of SaveOption are always paired with a subclass of ValueOption, with
+    SaveOption coming first.
+    """
+
+    def __init__(
+        cls, name: str, bases: tuple[type, ...], namespace: dict[str, Any], /, **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        super().__init__(name, bases, namespace)
+
+        # Ignore itself
+        if not bases:
+            return
+
+        # Ensure SaveOption comes before ValueOption in the inheritance
+        base_names = [base.__name__ for base in bases]
+        if "SaveOption" in base_names:
+            index_saveoption = base_names.index("SaveOption")
+
+            if not any(
+                issubclass(bases[i], ValueOption) for i in range(index_saveoption + 1, len(bases))
+            ):
+                raise TypeError(
+                    f"Class {name} must inherit from {SaveOption.__name__} before"
+                    f" {ValueOption.__name__}",
+                )
+
+
+@dataclass
+class SaveOption(metaclass=SaveOptionMeta):
+    """
+    Mixin class to make an option per-save, and disguise it as a button when saves are unavailable.
+
+    Must be inherited from *before* BaseOption, i.e.
+        class MySaveOption(SaveOption, SliderOption): ...
+    """
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Overriding __setattr__ from ValueOption so that we can set our var to tell if a value
+        # has been changed, which is then used to save the file when we leave the options menu.
+
+        # This calls the version from ValueOption due to Python's MRO. Our metaclass ensures that
+        # we're paired with ValueOption
+        super().__setattr__(name, value)
+
+        # We're editing this var to track if an option has changed since the last time the game
+        # was saved. Saving when the menu closes instead of on change of each item.
+        global any_option_changed
+        any_option_changed = True
+
+    def __getattribute__(self, item: str) -> Any:
+        # The __class__ variable is whatever the main class in most cases, and a ButtonOption
+        # when we can't save. ButtonOption implements only on_press and __call__ from BaseOption.
+        # We don't need the latter since it will be overridden by whatever ValueOption this is
+        # mixed with.
+        if can_save():
+            return super().__getattribute__(item)
+        if item == "__class__":
+            return ButtonOption
+        if item == "description":
+            return "Per save setting not available without a character loaded"
+        if item == "on_press":
+            return None
+        return super().__getattribute__(item)
+
+
+@dataclass
+class HiddenSaveOption[J: JSON](SaveOption, HiddenOption[J]):
+    """
+    A generic save option which is always hidden.
+
+    Use this to persist arbitrary (JSON-encodable) data in the character save file. This class
+    is explicitly intended to be modified programmatically, unlike the other options
+    which are generally only modified by the mod menu.
+
+    Args:
+        identifier: The option's identifier.
+        value: The option's value.
+    Keyword Args:
+        display_name: The option name to use for display. Defaults to copying the identifier.
+        description: A short description about the option.
+        description_title: The title of the description. Defaults to copying the display name.
+    Extra Attributes:
+        is_hidden: Always true.
+        mod: The mod this option stores it's settings in, or None if not (yet) associated with one.
+    """
+
+    def save(self) -> None:
+        """
+        Base HiddenOption has a method to save mod settings.
+
+        We're overriding to re-save the player save game and save our options on the character save
+        file.
+        """
+        trigger_save()
+
+
+@dataclass
+class SliderSaveOption(SaveOption, SliderOption):
+    """
+    A save option selecting a number within a range.
+
+    Value is stored on a per save basis when using this instead of the mod's settings file.
+
+    Args:
+        identifier: The option's identifier.
+        value: The option's value.
+        min_value: The minimum value.
+        max_value: The maximum value.
+        step: How much the value should move each step of the slider.
+        is_integer: If True, the value is treated as an integer.
+    Keyword Args:
+        display_name: The option name to use for display. Defaults to copying the identifier.
+        description: A short description about the option.
+        description_title: The title of the description. Defaults to copying the display name.
+        is_hidden: If true, the option will not be shown in the options menu.
+        on_change: If not None, a callback to run before updating the value. Passed a reference to
+                   the option object and the new value. May be set using decorator syntax.
+    Extra Attributes:
+        mod: The mod this option stores it's settings in, or None if not (yet) associated with one.
+        default_value: What the value was originally when registered. Does not update on change.
+    """
+
+
+@dataclass
+class SpinnerSaveOption(SaveOption, SpinnerOption):
+    """
+    A save option selecting one of a set of strings.
+
+    Typically implemented as a spinner. Value is stored on a per save basis when using this
+    instead of the mod's settings file.
+
+    Also see DropDownSaveOption, which may be more suitable for larger numbers of choices.
+
+    Args:
+        identifier: The option's identifier.
+        value: The option's value.
+        choices: A list of choices for the value.
+        wrap_enabled: If True, allows moving from the last choice back to the first, or vice versa.
+    Keyword Args:
+        display_name: The option name to use for display. Defaults to copying the identifier.
+        description: A short description about the option.
+        description_title: The title of the description. Defaults to copying the display name.
+        is_hidden: If true, the option will not be shown in the options menu.
+        on_change: If not None, a callback to run before updating the value. Passed a reference to
+                   the option object and the new value. May be set using decorator syntax.
+    Extra Attributes:
+        mod: The mod this option stores it's settings in, or None if not (yet) associated with one.
+        default_value: What the value was originally when registered. Does not update on change.
+    """
+
+
+@dataclass
+class BoolSaveOption(SaveOption, BoolOption):
+    """
+    A save option toggling a boolean value.
+
+    Typically implemented as an "on/off" spinner. Value is stored on a per save basis when using
+    this instead of the mod's settings file.
+
+    Args:
+        identifier: The option's identifier.
+        value: The option's value.
+        true_text: If not None, overwrites the default text used for the True option.
+        false_text: If not None, overwrites the default text used for the False option.
+    Keyword Args:
+        display_name: The option name to use for display. Defaults to copying the identifier.
+        description: A short description about the option.
+        description_title: The title of the description. Defaults to copying the display name.
+        is_hidden: If true, the option will not be shown in the options menu.
+        on_change: If not None, a callback to run before updating the value. Passed a reference to
+                   the option object and the new value. May be set using decorator syntax.
+    Extra Attributes:
+        mod: The mod this option stores it's settings in, or None if not (yet) associated with one.
+        default_value: What the value was originally when registered. Does not update on change.
+    """

--- a/src/save_options/registration.py
+++ b/src/save_options/registration.py
@@ -1,0 +1,112 @@
+import contextlib
+import inspect
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from unrealsdk import logging
+
+from mods_base import BaseOption, GroupedOption, Mod, NestedOption
+from save_options.options import SaveOption
+
+# Allowing GroupedOption and NestedOption if all their children are SaveOption
+ModSaveOptions = dict[str, BaseOption]
+registered_save_options: dict[str, ModSaveOptions] = {}
+
+SaveCallback = Callable[[], None]
+save_callbacks: dict[str, SaveCallback] = {}
+
+LoadCallback = Callable[[], None]
+load_callbacks: dict[str, LoadCallback] = {}
+
+registered_mods: dict[str, Mod] = {}
+
+
+def _treat_as_save_option(obj: Any) -> bool:
+    if isinstance(obj, SaveOption):
+        return True
+    if isinstance(obj, GroupedOption | NestedOption):
+        if all(_treat_as_save_option(child) for child in obj.children):
+            return True
+        logging.error(
+            f"Option {obj.identifier} has both regular BaseOption and SaveOption"
+            f"defined as children. SaveOption instances will be ignored"  # noqa: COM812
+        )
+    return False
+
+
+def register_save_options(  # noqa: D417
+    mod: Mod,
+    *,
+    save_options: Sequence[BaseOption] | None = None,
+    on_save: Callable[[], None] | None = None,
+    on_load: Callable[[], None] | None = None,
+    mod_identifier: str | None = None,
+) -> None:
+    """
+    Registers save options - values stored on the save options are saved to the character save file.
+
+    Positional arg:
+        mod: The Mod instance.
+
+    Keyword Args:
+        save_options: A sequence of SaveOption instances to register. If None, variables in the
+                      calling module's scope are searched, and any SaveOption found is appended.
+        on_save: A callback to run any time the game is saved. Intended use is to update any
+                 SaveOption values before they are written to the save file. If None, we search the
+                calling module's scope for "on_save".
+        on_load: A callback to run right after the player's save data is applied to the player upon
+                 entering the game. Intended use is to apply any custom save option values to the
+                 player. If None, we search the calling module's scope for "on_load".
+        mod_identifier: A string to identify the mod in the save file. If None, module.__name__ is
+                        used.
+    """
+
+    # Get calling module and identifier
+    module = inspect.getmodule(inspect.stack()[1].frame)
+    if module is None:
+        raise ValueError("Unable to find calling module when registering save options!")
+
+    if not mod_identifier:
+        mod_identifier = module.__name__
+
+    # Maintaining a registry of mods that call this so that we can identify which mods are enabled
+    # when it's time to call the callbacks.
+    registered_mods[mod_identifier] = mod
+
+    new_save_options: list[BaseOption] = []
+    # Grab any save options in mod.options. If a save option is in a nested or grouped option,
+    # we are going to register the parent iff all children are save options. Otherwise we'll log
+    # an error.
+    if isinstance(mod, Mod): # type: ignore
+        new_save_options.extend([option for option in mod.options if _treat_as_save_option(option)])
+
+    # If save_options not given, module search for any other save options defined
+    if save_options is None:
+        new_save_options.extend(
+            [value for _, value in inspect.getmembers(module) if _treat_as_save_option(value)],
+        )
+    else:
+        for option in save_options:
+            if _treat_as_save_option(option):
+                new_save_options.append(option)
+            else:
+                logging.error(f"Cannot register {option} as a SaveOption")
+
+    # If the same save_option is gathered twice above, this will deduplicate
+    registered_save_options[mod_identifier] = {
+        save_opt.identifier: save_opt for save_opt in new_save_options
+    }
+
+    # Register on_save callback. Module search if not given as an arg.
+    if on_save is None:
+        with contextlib.suppress(AttributeError):
+            save_callbacks[mod_identifier] = module.on_save
+    else:
+        save_callbacks[mod_identifier] = on_save
+
+    # Register on_load callback. Module search if not given as an arg.
+    if on_load is None:
+        with contextlib.suppress(AttributeError):
+            load_callbacks[mod_identifier] = module.on_load
+    else:
+        load_callbacks[mod_identifier] = on_load


### PR DESCRIPTION
Module that enables saving arbitrary json-encodable data directly to the character save file. Original issue here:
https://github.com/bl-sdk/willow2-mod-manager/issues/1

The module extends mods_base.ValueOption and its subclasses by adding a set of SaveOption classes. The classes behave almost exactly like their parents, except their values are saved to the save file instead of to the mod's settings file. 

Some changes to note since apple's informal code review a few weeks ago:
- Updated mods_base submodule to latest commit that includes _to_json() and _from_json() methods for all options.
- Added an optional on_load callback that that runs as a post hook to LoadPlayerSaveGame. This allows for applying any custom save data to the character immediately after the regular save data has been applied.
- GroupedOption and NestedOption are handled by checking if every child is either Grouped/Nested or a Save Option. If so, it can be registered as a save option. The new _(to|from)_json() methods are used to convert the values to JSON.