### PR TITLE
Load default values for save options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Save Options v1.2
+- Fixed issue where loading a character with no save option data inherited option values from
+  previous character.
+
 ## v3.6: Easy Mode
 Fixed that `save_options.sdkmod` wasn't actually being included in the release zip. Whoops.
 

--- a/src/save_options/__init__.py
+++ b/src/save_options/__init__.py
@@ -25,7 +25,7 @@ __all__: tuple[str, ...] = (
     "register_save_options",
 )
 
-__version_info__: tuple[int, int] = (1, 1)
+__version_info__: tuple[int, int] = (1, 2)
 __version__: str = f"{__version_info__[0]}.{__version_info__[1]}"
 __author__: str = "bl-sdk"
 

--- a/src/save_options/hooks.py
+++ b/src/save_options/hooks.py
@@ -8,7 +8,7 @@ from unrealsdk.unreal import BoundFunction, UObject, WrappedArray, WrappedStruct
 
 import save_options.options
 from mods_base import JSON, get_pc, hook
-from save_options.options import trigger_save
+from save_options.options import set_option_to_default, trigger_save
 from save_options.registration import (
     ModSaveOptions,
     load_callbacks,
@@ -125,6 +125,13 @@ def end_load_game(_1: UObject, _2: WrappedStruct, ret: Any, _4: BoundFunction) -
     # We hook this to send data back to any registered mod save options. This gets called when
     # loading character in main menu also. No callback here because the timing of when this is
     # called doesn't make much sense to do anything with it. See hook on LoadPlayerSaveGame.
+
+    # Often we'll load a save from a character with no save data. We'll set all save options
+    # to default first to cover for any missing data.
+
+    for mod_save_options in registered_save_options.values():
+        for save_option in mod_save_options.values():
+            set_option_to_default(save_option)
 
     # This function returns the new save game object, so use a post hook and grab it from `ret`
     save_game = ret

--- a/src/save_options/options.py
+++ b/src/save_options/options.py
@@ -15,9 +15,23 @@ from mods_base import (
     get_pc,
     hook,
 )
-from mods_base.options import DropdownOption, KeybindOption
+from mods_base.options import BaseOption, DropdownOption, GroupedOption, KeybindOption, NestedOption
 
 any_option_changed: bool = False
+
+
+def set_option_to_default(save_option: BaseOption) -> None:
+    """
+    Sets an option's value to its default.
+
+    For GroupedOption and NestedOption, recursively sets all children to their default values.
+    """
+    if isinstance(save_option, ValueOption):
+        val_opt: ValueOption[Any] = save_option
+        val_opt.value = val_opt.default_value
+    elif isinstance(save_option, GroupedOption | NestedOption):
+        for child in save_option.children:
+            set_option_to_default(child)
 
 
 def can_save() -> bool:

--- a/src/save_options/options.py
+++ b/src/save_options/options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from unrealsdk import make_struct
 from unrealsdk.hooks import Type, prevent_hooking_direct_calls
@@ -26,12 +26,15 @@ def set_option_to_default(save_option: BaseOption) -> None:
 
     For GroupedOption and NestedOption, recursively sets all children to their default values.
     """
-    if isinstance(save_option, ValueOption):
-        val_opt: ValueOption[Any] = save_option
-        val_opt.value = val_opt.default_value
-    elif isinstance(save_option, GroupedOption | NestedOption):
-        for child in save_option.children:
-            set_option_to_default(child)
+    match save_option:
+        case ValueOption():
+            val_opt = cast(ValueOption[Any], save_option)
+            val_opt.value = val_opt.default_value
+        case GroupedOption() | NestedOption():
+            for child in save_option.children:
+                set_option_to_default(child)
+        case _:
+            pass
 
 
 def can_save() -> bool:


### PR DESCRIPTION
Adds functionality for all registered save options to be reverted to default when a save file is loaded, _before_ the custom save data is loaded into the options. This fixes an issue where characters with no custom save data inherited option values from whatever character was last loaded.

Grouped and nested options have all their children set to default recursively. 