### PR TITLE
Fix Save Options Issue with new characters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.8: 
+
+### Save Options v1.3
+- Fixed issue with newly created characters inheriting options from previously loaded character.
+
 ## v3.7: Meteor Shower
 
 ### [Console Mod Menu v1.6](https://github.com/bl-sdk/console_mod_menu/blob/master/Readme.md#v16)

--- a/src/save_options/__init__.py
+++ b/src/save_options/__init__.py
@@ -25,7 +25,7 @@ __all__: tuple[str, ...] = (
     "register_save_options",
 )
 
-__version_info__: tuple[int, int] = (1, 2)
+__version_info__: tuple[int, int] = (1, 3)
 __version__: str = f"{__version_info__[0]}.{__version_info__[1]}"
 __author__: str = "bl-sdk"
 

--- a/src/save_options/hooks.py
+++ b/src/save_options/hooks.py
@@ -120,21 +120,19 @@ def save_game(_1: UObject, args: WrappedStruct, _3: Any, _4: BoundFunction) -> N
     save_options.options.any_option_changed = False
 
 
-@hook("WillowGame.WillowSaveGameManager:EndLoadGame", Type.POST, immediately_enable=True)
-def end_load_game(_1: UObject, _2: WrappedStruct, ret: Any, _4: BoundFunction) -> None:  # noqa: D103
+@hook("WillowGame.WillowPlayerController:FinishSaveGameLoad", immediately_enable=True)
+def end_load_game(_1: UObject, args: WrappedStruct, _3: Any, _4: BoundFunction) -> None:  # noqa: D103
     # We hook this to send data back to any registered mod save options. This gets called when
     # loading character in main menu also. No callback here because the timing of when this is
     # called doesn't make much sense to do anything with it. See hook on LoadPlayerSaveGame.
 
     # Often we'll load a save from a character with no save data. We'll set all save options
     # to default first to cover for any missing data.
-
     for mod_save_options in registered_save_options.values():
         for save_option in mod_save_options.values():
             set_option_to_default(save_option)
 
-    # This function returns the new save game object, so use a post hook and grab it from `ret`
-    save_game = ret
+    save_game = args.SaveGame
     if not save_game:
         return
     extracted_save_data = _extract_save_data(save_game.UnloadableDlcLockoutList)


### PR DESCRIPTION
Save options was keeping values from a previously loaded character whenever a new character was started. The WillowSaveGameManager:EndLoadGame hook I was using never gets called on a new character, so setting the defaults gets skipped. This PR just changes the hook to WillowGame.WillowPlayerController:FinishSaveGameLoad, which gets called for both existing character loads and new character loads.

Also changed to a pre-hook because it appears that there are some cases that a character can be loaded into a map during this new function call, triggering our on_load callbacks. The callbacks would be useless if they occur before the save option values are loaded.

I tested on AnarchySaver and WeaponProficiencies, and both appear to work well with the change.