### PR TITLE
Prevent throwing KeyError when loading save options for deleted mod.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
         submodules: recursive
 
     - name: Run pyright
-      uses: jakebailey/pyright-action@v2
+      uses: jakebailey/pyright-action@v3
       with:
         working-directory: ./src
 
@@ -241,12 +241,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run Ruff Linting
-      uses: chartboost/ruff-action@v1
+      uses: astral-sh/ruff-action@v3
       with:
         src: ./src
 
     - name: Run Ruff Formatting
-      uses: chartboost/ruff-action@v1
+      uses: astral-sh/ruff-action@v3
       with:
         src: ./src
         args: format --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
         submodules: recursive
 
     - name: Run pyright
-      uses: jakebailey/pyright-action@v2
+      uses: jakebailey/pyright-action@v3su
       with:
         working-directory: ./src
 
@@ -241,12 +241,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run Ruff Linting
-      uses: chartboost/ruff-action@v1
+      uses: astral-sh/ruff-action@v3
       with:
         src: ./src
 
     - name: Run Ruff Formatting
-      uses: chartboost/ruff-action@v1
+      uses: astral-sh/ruff-action@v3
       with:
         src: ./src
         args: format --check

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Save Options v1.3
 - Fixed issue with newly created characters inheriting options from previously loaded character.
+- Fixed issue of save options from deleted mods preventing other data from loading.
 
 ## v3.7: Meteor Shower
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "*.pyi" = ["A002", "A003", "D418"]
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.408",
+    "ruff>=0.15.9",
+]

--- a/src/save_options/hooks.py
+++ b/src/save_options/hooks.py
@@ -145,7 +145,10 @@ def end_load_game(_1: UObject, _2: WrappedStruct, ret: Any, _4: BoundFunction) -
         return
 
     for mod_id, extracted_mod_data in extracted_save_data.items():
-        mod_save_options: ModSaveOptions = registered_save_options[mod_id]
+        mod_save_options: ModSaveOptions | None = registered_save_options.get(mod_id, None)
+        if mod_save_options is None:
+            logging.warning(f"Save data found for unregistered mod '{mod_id}', skipping.")
+            continue
         for identifier, extracted_value in extracted_mod_data.items():
             if save_option := mod_save_options.get(identifier):
                 save_option._from_json(extracted_value)  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Just need to continue to load other mods' data and log a warning when a mod we're loading data for doesn't exist anymore (user deleted).